### PR TITLE
feat: 画像エンコードに送る元データはBlobで送る

### DIFF
--- a/app/lib/features/condition/application/condition_providers.dart
+++ b/app/lib/features/condition/application/condition_providers.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:blooms/constants/collection_path.dart';
@@ -80,7 +79,7 @@ Future<void> conditionCreateImage(
     logger.info('Upload image: ${xFile.path}');
 
     final request = ProcessConditionContentImageRequest(
-      base64: base64.encode(await xFile.readAsBytes()),
+      blob: await xFile.readAsBytes(),
     );
 
     final response = await ref

--- a/app/lib/features/condition/application/condition_providers.g.dart
+++ b/app/lib/features/condition/application/condition_providers.g.dart
@@ -314,7 +314,7 @@ class _ConditionCreateTextProviderElement
 }
 
 String _$conditionCreateImageHash() =>
-    r'904e35a31ca8b088ffc614ff524955c5151083b7';
+    r'd37a26fd803674353a64f648b15cf58c79f1df25';
 
 /// See also [conditionCreateImage].
 @ProviderFor(conditionCreateImage)

--- a/app/lib/features/condition/domain/process_condition_content_image_request.dart
+++ b/app/lib/features/condition/domain/process_condition_content_image_request.dart
@@ -7,7 +7,7 @@ part 'process_condition_content_image_request.g.dart';
 @freezed
 abstract class ProcessConditionContentImageRequest
     with _$ProcessConditionContentImageRequest {
-  const factory ProcessConditionContentImageRequest({required String base64}) =
+  const factory ProcessConditionContentImageRequest({required List<int> blob}) =
       _ProcessConditionContentImageRequest;
 
   factory ProcessConditionContentImageRequest.fromJson(Json json) =>

--- a/app/lib/features/condition/domain/process_condition_content_image_request.freezed.dart
+++ b/app/lib/features/condition/domain/process_condition_content_image_request.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ProcessConditionContentImageRequest {
 
- String get base64;
+ List<int> get blob;
 /// Create a copy of ProcessConditionContentImageRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $ProcessConditionContentImageRequestCopyWith<ProcessConditionContentImageRequest
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProcessConditionContentImageRequest&&(identical(other.base64, base64) || other.base64 == base64));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProcessConditionContentImageRequest&&const DeepCollectionEquality().equals(other.blob, blob));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,base64);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(blob));
 
 @override
 String toString() {
-  return 'ProcessConditionContentImageRequest(base64: $base64)';
+  return 'ProcessConditionContentImageRequest(blob: $blob)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $ProcessConditionContentImageRequestCopyWith<$Res>  {
   factory $ProcessConditionContentImageRequestCopyWith(ProcessConditionContentImageRequest value, $Res Function(ProcessConditionContentImageRequest) _then) = _$ProcessConditionContentImageRequestCopyWithImpl;
 @useResult
 $Res call({
- String base64
+ List<int> blob
 });
 
 
@@ -66,10 +66,10 @@ class _$ProcessConditionContentImageRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProcessConditionContentImageRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? base64 = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? blob = null,}) {
   return _then(_self.copyWith(
-base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
-as String,
+blob: null == blob ? _self.blob : blob // ignore: cast_nullable_to_non_nullable
+as List<int>,
   ));
 }
 
@@ -80,10 +80,16 @@ as String,
 @JsonSerializable()
 
 class _ProcessConditionContentImageRequest implements ProcessConditionContentImageRequest {
-  const _ProcessConditionContentImageRequest({required this.base64});
+  const _ProcessConditionContentImageRequest({required final  List<int> blob}): _blob = blob;
   factory _ProcessConditionContentImageRequest.fromJson(Map<String, dynamic> json) => _$ProcessConditionContentImageRequestFromJson(json);
 
-@override final  String base64;
+ final  List<int> _blob;
+@override List<int> get blob {
+  if (_blob is EqualUnmodifiableListView) return _blob;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_blob);
+}
+
 
 /// Create a copy of ProcessConditionContentImageRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -98,16 +104,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProcessConditionContentImageRequest&&(identical(other.base64, base64) || other.base64 == base64));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProcessConditionContentImageRequest&&const DeepCollectionEquality().equals(other._blob, _blob));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,base64);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_blob));
 
 @override
 String toString() {
-  return 'ProcessConditionContentImageRequest(base64: $base64)';
+  return 'ProcessConditionContentImageRequest(blob: $blob)';
 }
 
 
@@ -118,7 +124,7 @@ abstract mixin class _$ProcessConditionContentImageRequestCopyWith<$Res> impleme
   factory _$ProcessConditionContentImageRequestCopyWith(_ProcessConditionContentImageRequest value, $Res Function(_ProcessConditionContentImageRequest) _then) = __$ProcessConditionContentImageRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String base64
+ List<int> blob
 });
 
 
@@ -135,10 +141,10 @@ class __$ProcessConditionContentImageRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProcessConditionContentImageRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? base64 = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? blob = null,}) {
   return _then(_ProcessConditionContentImageRequest(
-base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
-as String,
+blob: null == blob ? _self._blob : blob // ignore: cast_nullable_to_non_nullable
+as List<int>,
   ));
 }
 

--- a/app/lib/features/condition/domain/process_condition_content_image_request.g.dart
+++ b/app/lib/features/condition/domain/process_condition_content_image_request.g.dart
@@ -14,11 +14,14 @@ _$ProcessConditionContentImageRequestFromJson(Map<String, dynamic> json) =>
       $checkedConvert,
     ) {
       final val = _ProcessConditionContentImageRequest(
-        base64: $checkedConvert('base64', (v) => v as String),
+        blob: $checkedConvert(
+          'blob',
+          (v) => (v as List<dynamic>).map((e) => (e as num).toInt()).toList(),
+        ),
       );
       return val;
     });
 
 Map<String, dynamic> _$ProcessConditionContentImageRequestToJson(
   _ProcessConditionContentImageRequest instance,
-) => <String, dynamic>{'base64': instance.base64};
+) => <String, dynamic>{'blob': instance.blob};

--- a/firebase/functions/src/features/image/domain/processConditionContentImageRequest.ts
+++ b/firebase/functions/src/features/image/domain/processConditionContentImageRequest.ts
@@ -1,3 +1,4 @@
 export interface ProcessConditionContentImageRequest {
-  base64: string;
+  base64: string | null;
+  blob: ArrayBuffer | null;
 }

--- a/firebase/functions/src/features/image/processConditionContentImage.ts
+++ b/firebase/functions/src/features/image/processConditionContentImage.ts
@@ -22,10 +22,18 @@ export const processConditionContentImage = onCall({
     throw new Error('Unauthorized');
   }
 
-  const date = request.data as ProcessConditionContentImageRequest;
+  const req = request.data as ProcessConditionContentImageRequest;
 
-  // base64の画像をデコード
-  const buffer = Buffer.from(date.base64, 'base64');
+  let buffer: Buffer;
+  if (req.base64 != null) {
+    // Base64にエンコードされた画像
+    buffer = Buffer.from(req.base64, 'base64');
+  } else if (req.blob != null) {
+    // Blobの画像
+    buffer = Buffer.from(req.blob);
+  } else {
+    throw new Error('Invalid image data');
+  }
 
   // リサイズ
   const resizedImage = sharp(buffer)


### PR DESCRIPTION
fixed #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 画像アップロード処理が、Base64エンコードされたデータだけでなく、直接のバイナリデータにも対応するようになりました。

- **リファクタ**
  - 画像データの変換とデコード処理が改善され、入力内容に応じたエラーハンドリングが強化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->